### PR TITLE
点击链接内的图片默认不触发预览

### DIFF
--- a/packages/example/components/doc-button.tsx
+++ b/packages/example/components/doc-button.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { PhotoProvider, PhotoView } from 'react-photo-view';
 import { Button, ImageList } from './doc-components';
 import photo4 from '../images/4.jpg';
+import photo5 from '../images/5.jpg';
 
 export default function DocDemo() {
   return (
@@ -9,6 +10,11 @@ export default function DocDemo() {
       <ImageList>
         <PhotoView src={photo4.src}>
           <Button primary>Click</Button>
+        </PhotoView>
+        <PhotoView src={photo5.src}>
+          <Button secondary>
+            <a href="/" target="_blank">react-photo-view</a> is an awesome library!
+          </Button>
         </PhotoView>
       </ImageList>
     </PhotoProvider>

--- a/packages/example/components/doc-components.tsx
+++ b/packages/example/components/doc-components.tsx
@@ -20,10 +20,11 @@ export const Image = React.forwardRef<HTMLImageElement, React.ImgHTMLAttributes<
 
 interface ButtonProps extends React.HtmlHTMLAttributes<HTMLDivElement> {
   primary?: boolean;
+  secondary?: boolean;
   children?: React.ReactNode;
 }
 
-export const Button = React.forwardRef<HTMLDivElement, ButtonProps>(({ primary, className = '', ...props }, ref) => {
+export const Button = React.forwardRef<HTMLDivElement, ButtonProps>(({ primary, secondary, className = '', ...props }, ref) => {
   return (
     <div
       {...props}
@@ -31,7 +32,7 @@ export const Button = React.forwardRef<HTMLDivElement, ButtonProps>(({ primary, 
       className={`px-4 py-2 mr-2 rounded-md focus:outline-none cursor-pointer select-none ${
         primary
           ? 'bg-sky-600 text-white hover:bg-sky-700'
-          : 'border border-gray-300 hover:text-white hover:bg-sky-500 hover:border-sky-500'
+          : `border border-gray-300 hover:text-white hover:border-sky-500 ${secondary ? '' : 'hover:bg-sky-500'}`
       } ${className}`}
     />
   );

--- a/packages/example/pages/docs/api.en-US.mdx
+++ b/packages/example/pages/docs/api.en-US.mdx
@@ -28,13 +28,14 @@ title: API
 
 ## PhotoView
 
-| Name     | Description                               | Type                                                | Default Value |
-| -------- | ----------------------------------------- | --------------------------------------------------- | ------------- |
-| src      | Image src                                 | string                                              |
-| render   | Custom rendering, lower priority than src | \(props: PhotoRenderParams\) =&gt; React\.ReactNode |
-| width    | Custom render node width                  | number                                              |
-| height   | Custom render node height                 | number                                              |
-| children | Child nodes, usually thumbnails           | React\.ReactElement                                 |
+| Name             | Description                                            | Type                                                      | Default Value |
+| ---------------- | ------------------------------------------------------ | --------------------------------------------------------- | ------------- |
+| src              | Image src                                              | string                                                    |
+| render           | Custom rendering, lower priority than src              | \(props: PhotoRenderParams\) =&gt; React\.ReactNode       |
+| width            | Custom render node width                               | number                                                    |
+| height           | Custom render node height                              | number                                                    |
+| children         | Child nodes, usually thumbnails                        | React\.ReactElement                                       |
+| shouldOpenSlider | Whether the slider should open when content is clicked | \(e: React.MouseEvent \| React\.TouchEvent) =&gt; boolean |
 
 ## DataType
 

--- a/packages/example/pages/docs/api.zh-CN.mdx
+++ b/packages/example/pages/docs/api.zh-CN.mdx
@@ -28,13 +28,14 @@ title: API
 
 ## PhotoView
 
-| Name     | Description                 | Type                                                | Default Value |
-| -------- | --------------------------- | --------------------------------------------------- | ------------- |
-| src      | 图片地址                    | string                                              |
-| render   | 自定义渲染，优先级比 src 低 | \(props: PhotoRenderParams\) =&gt; React\.ReactNode |
-| width    | 自定义渲染节点宽度          | number                                              |
-| height   | 自定义渲染节点高度          | number                                              |
-| children | 子节点，一般为缩略图        | React\.ReactElement                                 |
+| Name             | Description                 | Type                                                | Default Value |
+| ---------------- | --------------------------- | --------------------------------------------------- | ------------- |
+| src              | 图片地址                    | string                                              |
+| render           | 自定义渲染，优先级比 src 低 | \(props: PhotoRenderParams\) =&gt; React\.ReactNode |
+| width            | 自定义渲染节点宽度          | number                                              |
+| height           | 自定义渲染节点高度          | number                                              |
+| children         | 子节点，一般为缩略图        | React\.ReactElement                                 |
+| shouldOpenSlider | 点击内容时是否打开预览      | \(e: React.MouseEvent \| React\.TouchEvent) =&gt; boolean |
 
 ## DataType
 

--- a/packages/example/pages/docs/change-log.en-US.mdx
+++ b/packages/example/pages/docs/change-log.en-US.mdx
@@ -2,6 +2,11 @@
 title: Change Log
 ---
 
+## UNPUBLISHED
+
+1. fix: Prevent showing slider by default when click inside a link
+2. feat: Add API `shouldOpenSlider`
+
 ## 1.0.0-beta.8
 
 1. fix: Inaccurate zoom position after `onScale` API call

--- a/packages/example/pages/docs/change-log.zh-CN.mdx
+++ b/packages/example/pages/docs/change-log.zh-CN.mdx
@@ -2,6 +2,11 @@
 title: Change Log
 ---
 
+## UNPUBLISHED
+
+1. fix: 当点击链接中的图片时，默认不打开预览
+2. feat: 添加 API `shouldOpenSlider`
+
 ## 1.0.0-beta.8
 
 1. fix: `onScale` API 调用后缩放位置不准确的问题

--- a/packages/example/pages/docs/getting-started.en-US.mdx
+++ b/packages/example/pages/docs/getting-started.en-US.mdx
@@ -180,9 +180,16 @@ When loading images whose aspect ratio exceeds `3` times, the mobile device will
 
 If it is a custom component, you need to ensure that `onClick` (desktop), `onTouchStart` and `onTouchEnd` (mobile) events can be triggered normally, and forward `ref` to `HTMLElement` to ensure the correctness of opening and closing the animation source.
 
+By default, preview shows only when the event target is NOT descendent of an `<a />` element, in order to prevent triggering preview inside a link. You can pass `shouldOpenSlider` function to customize this behavior.
+
 ```jsx
-<PhotoView src={imageURL}>
+<PhotoView src={imageURL1}>
   <Button primary>Click</Button>
+</PhotoView>
+<PhotoView src={imageURL2}>
+  <Button secondary>
+    <a href="/">react-photo-view</a> is an awesome library!
+  </Button>
 </PhotoView>
 ```
 

--- a/packages/example/pages/docs/getting-started.zh-CN.mdx
+++ b/packages/example/pages/docs/getting-started.zh-CN.mdx
@@ -179,9 +179,16 @@ export default function MyComponent() {
 
 如果是自定义组件则需要保证 `onClick` （桌面端），`onTouchStart` 和 `onTouchEnd` （移动端）事件能正常触发，转发 `ref` 到 `HTMLElement` 上保证打开/关闭动画源的正确性。
 
+为了防止链接内的图片触发预览，默认只有当前触发点击事件的元素是不是 `<a />` 标签的子元素时，才会打开图片预览。如果需要改变这一行为，可以通过 `shouldOpenSlider` 方法实现自定义逻辑。
+
 ```jsx
-<PhotoView src={imageURL}>
+<PhotoView src={imageURL1}>
   <Button primary>Click</Button>
+</PhotoView>
+<PhotoView src={imageURL2}>
+  <Button secondary>
+    <a href="/">react-photo-view</a> is an awesome library!
+  </Button>
 </PhotoView>
 ```
 

--- a/packages/example/pages/docs/getting-started.zh-CN.mdx
+++ b/packages/example/pages/docs/getting-started.zh-CN.mdx
@@ -179,7 +179,7 @@ export default function MyComponent() {
 
 如果是自定义组件则需要保证 `onClick` （桌面端），`onTouchStart` 和 `onTouchEnd` （移动端）事件能正常触发，转发 `ref` 到 `HTMLElement` 上保证打开/关闭动画源的正确性。
 
-为了防止链接内的图片触发预览，默认只有当前触发点击事件的元素是不是 `<a />` 标签的子元素时，才会打开图片预览。如果需要改变这一行为，可以通过 `shouldOpenSlider` 方法实现自定义逻辑。
+为了防止链接内的图片触发预览，默认只有当前触发点击事件的元素不是 `<a />` 标签的子元素时，才会打开图片预览。如果需要改变这一行为，可以通过 `shouldOpenSlider` 方法实现自定义逻辑。
 
 ```jsx
 <PhotoView src={imageURL1}>

--- a/packages/react-photo-view/src/utils/findAncestor.ts
+++ b/packages/react-photo-view/src/utils/findAncestor.ts
@@ -1,0 +1,12 @@
+/**
+ * 查找符合条件的祖先元素
+ */
+ export default function findAncestor(element: HTMLElement | null, where: (e: HTMLElement) => boolean | undefined): HTMLElement | null {
+  if (!element || element === document.body) {
+    return null;
+  }
+  if (where(element)) {
+    return element;
+  }
+  return findAncestor(element.parentElement, where);
+}


### PR DESCRIPTION
为了防止链接内的图片触发预览，`<PhotoView>` 的默认逻辑调整为只有当前触发点击事件的元素不是 `<a />` 标签的子元素时，才会打开图片预览。

如果需要改变这一行为，可以通过 `shouldOpenSlider?: (e: (React.TouchEvent | React.MouseEvent)) => boolean` 方法实现自定义逻辑。

case 1:

```jsx
<PhotoView src={imageURL1}>
  <Button secondary>
    <a href="/">react-photo-view</a> is an awesome library!
  </Button>
</PhotoView>
```

case 2:

```jsx
<a href="/">
  <span>Text link</span>
  <PhotoView src={imageURL2}>
    <img src="and/image/link" />
  </PhotoView>
</a>
```

以上两例，点击链接时不应触发预览浮层。

原有逻辑可以通过 `<PhotoView ... shouldOpenSlider={() => true}>` 实现。用户也可以通过对传入的 event 对象进行判断实现更复杂的逻辑。