### PR TITLE
查看图片的方法内，增加是否阻止浏览器默认事件配置

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
-  "name": "root",
+  "name": "react-photo-view-patch-1",
   "private": true,
+  "version": "1.2.3",
   "description": "An exquisite React photo preview component",
   "author": "MinJieLiu",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-photo-view-patch-1",
+  "name": "react-photo-view",
   "private": true,
   "version": "1.2.3",
   "description": "An exquisite React photo preview component",

--- a/packages/react-photo-view/src/PhotoView.tsx
+++ b/packages/react-photo-view/src/PhotoView.tsx
@@ -36,6 +36,10 @@ export interface PhotoViewProps {
    * 触发的事件
    */
   triggers?: ('onClick' | 'onDoubleClick')[];
+  /**
+   * 点击图片是否阻止浏览器默认事件
+   */
+  preventDefault?: boolean;
 }
 
 const PhotoView: React.FC<PhotoViewProps> = ({
@@ -58,6 +62,9 @@ const PhotoView: React.FC<PhotoViewProps> = ({
   }, []);
 
   function invokeChildrenFn(eventName: string, e: React.SyntheticEvent) {
+    if (preventDefault) {
+       e.preventDefault()
+    }
     if (children) {
       const eventFn = children.props[eventName];
       if (eventFn) {


### PR DESCRIPTION
点击图片查看大图时，如果父组件存在点击事件或路由跳转，会同时触发查看和父组件的事件，增加preventDefault以支持要阻止父组件事件的场景。