### PR TITLE
移动端在rax类的框架中图片宽高单位被转换问题

### DIFF
--- a/packages/react-photo-view/src/PhotoBox.tsx
+++ b/packages/react-photo-view/src/PhotoBox.tsx
@@ -425,8 +425,8 @@ export default function PhotoBox({
     onTouchStart: isTouchDevice ? handleTouchStart : undefined,
     onWheel: handleWheel,
     style: {
-      width: currentWidth,
-      height: currentHeight,
+      width: currentWidth + 'px',
+      height: currentHeight + 'px',
       opacity,
       objectFit: easingMode === 4 ? undefined : FIT,
       transform: rotate ? `rotate(${rotate}deg)` : undefined,


### PR DESCRIPTION
图片内联宽高样式不带单位在rax类的框架中会被转成vw和vh，导致渲染出来的图片宽高比实际小了