### PR TITLE
fix: custom render node offset NaN

### DIFF
--- a/packages/example/components/doc-render.tsx
+++ b/packages/example/components/doc-render.tsx
@@ -13,7 +13,7 @@ export default function DocDemo() {
           height={elementSize}
           // @ts-ignore
           render={({ scale, attrs }) => {
-            const width = attrs.style!.width as number;
+            const width = parseFloat((attrs?.style?.width ?? 0) as string);
             const offset = (width - elementSize) / elementSize;
             // 保持子节点的 scale 的稳定
             const childScale = scale === 1 ? scale + offset : 1 + offset;

--- a/packages/example/pages/docs/getting-started.en-US.mdx
+++ b/packages/example/pages/docs/getting-started.en-US.mdx
@@ -262,7 +262,7 @@ function MyComponent() {
       width={elementSize}
       height={elementSize}
       render={({ scale, attrs }) => {
-        const width = attrs.style.width;
+        const width = parseFloat((attrs?.style?.width ?? 0) as string);
         const offset = (width - elementSize) / elementSize;
         const childScale = scale === 1 ? scale + offset : 1 + offset;
 

--- a/packages/example/pages/docs/getting-started.zh-CN.mdx
+++ b/packages/example/pages/docs/getting-started.zh-CN.mdx
@@ -261,7 +261,7 @@ function MyComponent() {
       width={elementSize}
       height={elementSize}
       render={({ scale, attrs }) => {
-        const width = attrs.style.width;
+        const width = parseFloat((attrs?.style?.width ?? 0) as string);
         const offset = (width - elementSize) / elementSize;
         const childScale = scale === 1 ? scale + offset : 1 + offset;
 


### PR DESCRIPTION
When `attrs?.style?.width` is a string, such as '390px', subtracting a number like `'390px' - 100` can result in a "Not a Number" issue, causing the custom node rendering and scaling to fail.